### PR TITLE
Refine greeting flow and remove DTMF menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Dental Voice Receptionist
 
-A FastAPI application that turns a Twilio voice number into a warm, UK-style dental receptionist. The assistant greets callers with varied openings, handles hours/address/prices/booking questions, captures booking details, keeps a running transcript, and learns from each day of calls.
+A FastAPI application that turns a Twilio voice number into a warm, UK-style dental receptionist. The assistant opens every call with a consistent, human-like introduction, handles hours/address/prices/booking questions, captures booking details, keeps a running transcript, and learns from each day of calls.
 
 ## Key features
 
 - FastAPI webhooks on port **5173** with `/health`, `/voice`, `/gather-intent`, `/gather-booking`, and `/status` routes.
-- Speech-first Twilio `<Gather>` prompts with barge-in support, keypad shortcuts, and varied conversational fillers.
+- Natural, scripted introduction that sets expectations and explains how the assistant can help.
+- Speech-only Twilio `<Gather>` prompts with barge-in support and varied conversational fillers—no keypad menus to memorise.
 - Environment-driven Polly voice selection (default `Polly.Amy` with `alice` fallback) and short, natural UK prompts.
 - Per-call memory keyed by `CallSid`, including transcripts, caller name, intent, requested time, and retry counters.
 - Automatic persistence:
@@ -68,8 +69,8 @@ Copy the HTTPS forwarding URL (for example `https://random.ngrok.app`) for the T
 
 ## How the receptionist behaves
 
-- 10–15 varied greetings are chosen at random per call, all in a friendly UK tone.
-- `<Gather>` prompts accept both speech and DTMF (1–4) with barge-in enabled so callers can interrupt.
+- Every call starts with: “Hi, thanks for calling our dental practice. I’m your AI receptionist, here to help with general information and booking appointments. Please note, I’m not a medical professional. You can ask about our opening hours, our address, our prices, or say you’d like to book an appointment.”
+- `<Gather>` prompts listen for natural speech with barge-in enabled so callers can interrupt—no keypad presses required.
 - The bot answers questions about opening hours, address, and prices using:
   - `HOURS_LINE`: “We're open Monday to Friday, nine till five; Saturdays ten till two; Sundays closed.”
   - `ADDRESS_LINE`: “We're at 12 Market Street, Central Milton Keynes, MK9 3QA.”

--- a/app/dialogue.py
+++ b/app/dialogue.py
@@ -4,21 +4,12 @@ import random
 from typing import Optional
 
 
-GREETINGS = [
-    "Hello, you're through to Market Street Dental.",
-    "Hi there, thanks for calling Market Street Dental.",
-    "Good day, Market Street Dental reception speaking.",
-    "Hello, Market Street Dental on the line.",
-    "Hi, you've reached the Market Street Dental team.",
-    "Hello there, Market Street Dental reception here.",
-    "Morning, Market Street Dental here.",
-    "Afternoon, Market Street Dental, how can I help?",
-    "Hiya, Market Street Dental practice speaking.",
-    "Thanks for ringing Market Street Dental.",
-    "Hello, Market Street Dental, what can I do for you?",
-    "Hi, Market Street Dental, lovely to hear from you.",
-    "Hello, Market Street Dental, how may I help today?",
-]
+MENU_GREETING = (
+    "Hi, thanks for calling our dental practice. I’m your AI receptionist, here to help with "
+    "general information and booking appointments. Please note, I’m not a medical professional. "
+    "You can ask about our opening hours, our address, our prices, or say you’d like to book an "
+    "appointment."
+)
 
 HOLDERS = [
     "Okay, that's fine.",
@@ -91,8 +82,8 @@ PRICES_LINE = (
 ANYTHING_ELSE_PROMPT = "Is there anything else I can help you with?"
 
 
-def pick_greeting() -> str:
-    return random.choice(GREETINGS)
+def build_menu_prompt() -> str:
+    return MENU_GREETING
 
 
 def pick_holder() -> str:

--- a/app/intent.py
+++ b/app/intent.py
@@ -49,21 +49,7 @@ _AFFIRM_KEYWORDS = {
     "sounds good",
 }
 
-_DIGIT_INTENT = {
-    "1": "hours",
-    "2": "address",
-    "3": "prices",
-    "4": "booking",
-}
-
-
-def parse_intent(speech: Optional[str], digits: Optional[str]) -> Optional[str]:
-    if digits:
-        for digit in digits:
-            intent = _DIGIT_INTENT.get(digit)
-            if intent:
-                return intent
-
+def parse_intent(speech: Optional[str]) -> Optional[str]:
     if not speech:
         return None
 

--- a/app/state.py
+++ b/app/state.py
@@ -21,6 +21,7 @@ class CallState:
     transcript_file: Optional[str] = None
     final_goodbye: Optional[str] = None
     metadata: Dict[str, Optional[str]] = field(default_factory=dict)
+    has_greeted: bool = False
 
     def add_system_line(self, text: str) -> None:
         text = text.strip()

--- a/app/twiml.py
+++ b/app/twiml.py
@@ -40,8 +40,7 @@ def gather_for_intent(prompt: str, voice: str, language: str) -> str:
         voice,
         language,
         action="/gather-intent",
-        allow_digits=True,
-        num_digits=1,
+        allow_digits=False,
         hints="hours,address,prices,book",
     )
 
@@ -52,8 +51,7 @@ def gather_for_follow_up(prompt: str, voice: str, language: str) -> str:
         voice,
         language,
         action="/gather-intent",
-        allow_digits=True,
-        num_digits=1,
+        allow_digits=False,
         hints="yes,no,bye",
     )
 

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,26 +1,20 @@
 from app.intent import parse_intent
 
-
-def test_digits_map_to_intent():
-    assert parse_intent(None, "1") == "hours"
-    assert parse_intent(None, "4") == "booking"
-
-
 def test_speech_keywords_match():
-    assert parse_intent("Can I book a visit?", None) == "booking"
-    assert parse_intent("What's your address?", None) == "address"
-    assert parse_intent("How much is a checkup?", None) == "prices"
-    assert parse_intent("What time are you open?", None) == "hours"
+    assert parse_intent("Can I book a visit?") == "booking"
+    assert parse_intent("What's your address?") == "address"
+    assert parse_intent("How much is a checkup?") == "prices"
+    assert parse_intent("What time are you open?") == "hours"
 
 
 def test_goodbye_detection():
-    assert parse_intent("No thanks, that's all", None) == "goodbye"
-    assert parse_intent("bye bye", None) == "goodbye"
+    assert parse_intent("No thanks, that's all") == "goodbye"
+    assert parse_intent("bye bye") == "goodbye"
 
 
 def test_affirm_detection():
-    assert parse_intent("Yes please", None) == "affirm"
+    assert parse_intent("Yes please") == "affirm"
 
 
 def test_unknown_returns_none():
-    assert parse_intent("I want to talk about something else", None) is None
+    assert parse_intent("I want to talk about something else") is None

--- a/tests/test_twiml.py
+++ b/tests/test_twiml.py
@@ -20,11 +20,19 @@ def _get_gather(xml: str) -> ET.Element:
     return gather
 
 
-def test_gather_intent_allows_dtmf():
+def test_gather_intent_is_speech_only():
     twiml = gather_for_intent("Tell me how to help", VOICE, LANG)
     gather = _get_gather(twiml)
-    assert gather.attrib["input"] == "speech dtmf"
-    assert gather.attrib.get("numDigits") == "1"
+    assert gather.attrib["input"] == "speech"
+    assert "numDigits" not in gather.attrib
+    assert gather.attrib["action"] == "/gather-intent"
+
+
+def test_follow_up_gather_is_speech_only():
+    twiml = gather_for_follow_up("Anything else?", VOICE, LANG)
+    gather = _get_gather(twiml)
+    assert gather.attrib["input"] == "speech"
+    assert "numDigits" not in gather.attrib
     assert gather.attrib["action"] == "/gather-intent"
 
 


### PR DESCRIPTION
## Summary
- replace the random greeting with a scripted introduction and adjust prompts to reference speech-only intents
- ensure the voice webhook only plays the greeting once, treat silence with polite follow-ups, and remove DTMF handling
- document the new call experience and keep Polly Amy (en-GB) as the default voice with alice fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1334a50948330b926275d1b22b37d