### PR TITLE
Capture call transcripts and add debug endpoint

### DIFF
--- a/app/debug.py
+++ b/app/debug.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Optional
 import itertools
 
+from app.persistence import transcript_get
+
 router = APIRouter()
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -34,3 +36,10 @@ def debug_logs(n: Optional[int] = Query(50, ge=1, le=500)):
     lines = LOG_FILE.read_text(encoding="utf-8", errors="ignore").splitlines()
     tail = list(itertools.islice(lines, max(0, len(lines) - (n or 50)), None))
     return PlainTextResponse("\n".join(tail), status_code=200)
+
+
+@router.get("/_debug/transcript")
+def debug_transcript(sid: str = Query(..., alias="sid")):
+    call_sid = (sid or "").strip()
+    lines = transcript_get(call_sid) if call_sid else []
+    return JSONResponse({"call_sid": call_sid, "lines": lines})

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -5,7 +5,13 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Lock
 from typing import Iterable, List, Optional
+
+try:  # Python 3.9+
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - fallback for very old runtimes
+    ZoneInfo = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +19,9 @@ TRANSCRIPTS_DIR = Path("transcripts")
 DATA_DIR = Path("data")
 BOOKINGS_CSV = DATA_DIR / "bookings.csv"
 CALLS_JSONL = DATA_DIR / "calls.jsonl"
+
+_TRANSCRIPTS: dict[str, List[str]] = {}
+_TRANSCRIPTS_LOCK = Lock()
 
 
 def ensure_storage() -> None:
@@ -41,9 +50,53 @@ def _next_transcript_index() -> int:
     return max_index + 1
 
 
+def transcript_init(call_sid: str) -> List[str]:
+    """Initialise the in-memory transcript for a call."""
+
+    with _TRANSCRIPTS_LOCK:
+        lines = _TRANSCRIPTS.pop(call_sid, [])
+        lines.clear()
+        _TRANSCRIPTS[call_sid] = lines
+        return lines
+
+
+def transcript_add(call_sid: str, role: str, text: str) -> None:
+    """Append a line to the transcript memory for a call."""
+
+    cleaned = (text or "").strip()
+    call_sid = (call_sid or "").strip()
+    if not call_sid:
+        return
+    if not cleaned:
+        return
+
+    clean_role = (role or "").strip() or "Agent"
+    if clean_role.lower() in {"agent", "caller"}:
+        clean_role = clean_role.title()
+    entry = f"[{clean_role}] {cleaned}"
+    with _TRANSCRIPTS_LOCK:
+        lines = _TRANSCRIPTS.setdefault(call_sid, [])
+        lines.append(entry)
+
+
+def transcript_get(call_sid: str) -> List[str]:
+    with _TRANSCRIPTS_LOCK:
+        return list(_TRANSCRIPTS.get(call_sid, []))
+
+
+def transcript_pop(call_sid: str) -> List[str]:
+    with _TRANSCRIPTS_LOCK:
+        return _TRANSCRIPTS.pop(call_sid, [])
+
+
 def save_transcript(call_sid: str, transcript: Iterable[str]) -> Path:
     ensure_storage()
     now = datetime.now()
+    if ZoneInfo is not None:
+        try:
+            now = datetime.now(tz=ZoneInfo("Europe/London"))
+        except Exception:  # pragma: no cover - zoneinfo lookup failure
+            now = datetime.now()
     index = _next_transcript_index()
     filename = f"AI Incoming Call {index:04d} {now:%H-%M} {now:%d-%m-%y}.txt"
     path = TRANSCRIPTS_DIR / filename
@@ -81,4 +134,13 @@ def append_call_record(summary: dict) -> None:
     logger.info("Logged call summary", extra={"call_sid": summary.get("call_sid")})
 
 
-__all__ = ["ensure_storage", "save_transcript", "append_booking", "append_call_record"]
+__all__ = [
+    "ensure_storage",
+    "save_transcript",
+    "append_booking",
+    "append_call_record",
+    "transcript_init",
+    "transcript_add",
+    "transcript_get",
+    "transcript_pop",
+]

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1,0 +1,29 @@
+def test_transcript_add_and_save(tmp_path, monkeypatch):
+    from app import persistence
+
+    transcripts_dir = tmp_path / "transcripts"
+    data_dir = tmp_path / "data"
+
+    monkeypatch.setattr(persistence, "TRANSCRIPTS_DIR", transcripts_dir)
+    monkeypatch.setattr(persistence, "DATA_DIR", data_dir)
+    monkeypatch.setattr(persistence, "BOOKINGS_CSV", data_dir / "bookings.csv")
+    monkeypatch.setattr(persistence, "CALLS_JSONL", data_dir / "calls.jsonl")
+    monkeypatch.setattr(persistence, "_TRANSCRIPTS", {})
+
+    persistence.ensure_storage()
+
+    call_sid = "TEST123"
+    persistence.transcript_init(call_sid)
+    persistence.transcript_add(call_sid, "Agent", "Hello there")
+    persistence.transcript_add(call_sid, "Caller", "I need an appointment")
+
+    lines = persistence.transcript_pop(call_sid)
+    assert lines == ["[Agent] Hello there", "[Caller] I need an appointment"]
+
+    transcript_path = persistence.save_transcript(call_sid, lines)
+
+    assert transcript_path.is_file()
+    content = transcript_path.read_text(encoding="utf-8")
+    assert "[Agent] Hello there" in content
+    assert "[Caller] I need an appointment" in content
+    assert content.strip() != ""


### PR DESCRIPTION
## Summary
- centralize transcript storage, expose helpers, and keep per-call transcripts flushed with London timestamps
- log agent prompts and caller speech through the new helper, add voice fallback handling, and expose an in-memory transcript debug endpoint
- document the transcript lifecycle, list the new debug endpoint, and add a regression test that exercises transcript saving

## Testing
- `pytest` *(fails: missing httpx/pyyaml dependencies in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d14fbe1bdc8330bded612bce012715