### PR TITLE
Implement real scheduling availability and booking flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ A FastAPI + Twilio voice assistant that behaves like a natural, speech-first den
   - Plain-text transcripts stored in `transcripts/AI Incoming Call <index> <HH-mm> <dd-MM-yy>.txt` with `[Agent]` / `[Caller]` lines.
   - Bookings appended to `data/bookings.csv` (`timestamp, call_sid, caller_name, requested_time, intent`).
   - Call summaries appended to `data/calls.jsonl` (`call_sid, finished_at, direction, from, to, duration_sec, caller_name, intent, requested_time, transcript_file`).
+- Availability & bookings
+  - The assistant reads `data/schedule.csv` for free times.
+  - Phrases like “what do you have tomorrow / on Wednesday” will list real times for that day.
+  - Booking order: type → day → time → name → confirm. On confirm, the slot is marked **Booked** in `data/schedule.csv` and a line is appended to `data/bookings.csv`.
+  - If a day is full, it suggests the next available slot.
 - Optional webhook signature validation and JSON-formatted logging controlled via environment variables.
 - Daily self-learning workflow that inspects transcripts, writes suggestions, and opens/updates a GitHub issue for review.
 

--- a/app/intent.py
+++ b/app/intent.py
@@ -19,6 +19,21 @@ _INTENT_KEYWORDS = {
     },
 }
 
+_AVAILABILITY_PATTERNS = {
+    "availability",
+    "available",
+    "what do you have",
+    "what times",
+    "what time slots",
+    "free slots",
+    "free time",
+    "free appointment",
+    "what can you do tomorrow",
+    "what can you do on",
+    "any slots",
+    "any availability",
+}
+
 _GOODBYE_KEYWORDS = {
     "bye",
     "goodbye",
@@ -62,8 +77,9 @@ def parse_intent(speech: Optional[str]) -> Optional[str]:
     def _contains(keyword: str) -> bool:
         return keyword in text if " " in keyword else keyword in words
 
-    if "what do you have" in text or "available" in words or "slots" in words:
-        return "availability"
+    booking_keywords = _INTENT_KEYWORDS.get("booking", set())
+    if any(_contains(keyword) for keyword in booking_keywords):
+        return "booking"
 
     for keyword in _GOODBYE_KEYWORDS:
         if _contains(keyword):
@@ -73,7 +89,12 @@ def parse_intent(speech: Optional[str]) -> Optional[str]:
         if _contains(keyword):
             return "affirm"
 
+    if any(pattern in text for pattern in _AVAILABILITY_PATTERNS):
+        return "availability"
+
     for intent, keywords in _INTENT_KEYWORDS.items():
+        if intent == "booking":
+            continue
         if any(_contains(keyword) for keyword in keywords):
             return intent
     return None

--- a/app/nlp.py
+++ b/app/nlp.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import calendar
+import re
+from datetime import date, datetime, timedelta
+
+
+def today_date() -> date:
+    return datetime.now().date()
+
+
+WEEKDAYS = {name.lower(): i for i, name in enumerate(calendar.day_name)}
+
+
+def parse_date_phrase(text: str) -> str | None:
+    if not text:
+        return None
+    lowered = text.lower().strip()
+    base = today_date()
+
+    if "today" in lowered:
+        return base.strftime("%Y-%m-%d")
+    if "tomorrow" in lowered:
+        return (base + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    for name, idx in WEEKDAYS.items():
+        if re.search(rf"\b{name[:3]}\w*\b", lowered):
+            delta = (idx - base.weekday()) % 7
+            if delta == 0:
+                delta = 7
+            return (base + timedelta(days=delta)).strftime("%Y-%m-%d")
+    return None
+
+
+def normalize_time(text: str) -> str | None:
+    if not text:
+        return None
+    lowered = text.lower().strip()
+    match = re.search(r"\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b", lowered)
+    if not match:
+        return None
+    hour = int(match.group(1))
+    minute = int(match.group(2) or 0)
+    ampm = (match.group(3) or "").lower()
+    if ampm == "pm" and hour < 12:
+        hour += 12
+    if ampm == "am" and hour == 12:
+        hour = 0
+    if not (0 <= hour < 24 and 0 <= minute < 60):
+        return None
+    return f"{hour:02d}:{minute:02d}"
+

--- a/app/schedule.py
+++ b/app/schedule.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import csv
 from pathlib import Path
-from typing import Iterable, List, Sequence
 
-try:  # pragma: no cover - optional dependency
-    import pandas as pd  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - optional dependency
-    pd = None  # type: ignore[assignment]
+import pandas as pd
+
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 SCHEDULE_FILE = DATA_DIR / "schedule.csv"
@@ -15,244 +11,43 @@ BOOKINGS_FILE = DATA_DIR / "bookings.csv"
 
 APPT_TYPES = ["Check-up", "Hygiene", "Whitening", "Filling", "Emergency"]
 
-DEFAULT_COLUMNS: Sequence[str] = (
-    "date",
-    "weekday",
-    "start_time",
-    "end_time",
-    "status",
-    "patient_name",
-    "appointment_type",
-    "notes",
-)
 
-
-class Mask:
-    __slots__ = ("_values",)
-
-    def __init__(self, values: Iterable[bool]):
-        self._values = [bool(v) for v in values]
-
-    @property
-    def values(self) -> List[bool]:
-        return list(self._values)
-
-    def __iter__(self):
-        return iter(self._values)
-
-    def __len__(self) -> int:
-        return len(self._values)
-
-    def __and__(self, other: object) -> "Mask":
-        if isinstance(other, Mask):
-            other_values = other._values
-        elif isinstance(other, Sequence):
-            other_values = [bool(v) for v in other]
-        else:  # pragma: no cover - defensive fallback
-            raise TypeError("Unsupported mask type for logical and")
-        if len(other_values) != len(self._values):
-            raise ValueError("Mask length mismatch")
-        return Mask(a and b for a, b in zip(self._values, other_values))
-
-    def any(self) -> bool:
-        return any(self._values)
-
-
-class _SeriesILoc:
-    __slots__ = ("_series",)
-
-    def __init__(self, series: "Series") -> None:
-        self._series = series
-
-    def __getitem__(self, index: int):
-        return self._series._values[index]
-
-
-class Series:
-    __slots__ = ("_df", "_column", "_values", "_indices")
-
-    def __init__(self, df: "SimpleDataFrame", column: str, values: Sequence, indices: Sequence[int]):
-        self._df = df
-        self._column = column
-        self._values = list(values)
-        self._indices = list(indices)
-
-    def __iter__(self):
-        return iter(self._values)
-
-    def __len__(self) -> int:
-        return len(self._values)
-
-    def __eq__(self, other: object) -> Mask:  # type: ignore[override]
-        return Mask(value == other for value in self._values)
-
-    @property
-    def iloc(self) -> _SeriesILoc:
-        return _SeriesILoc(self)
-
-
-class _Row:
-    __slots__ = ("_data",)
-
-    def __init__(self, data: dict):
-        self._data = data
-
-    def to_dict(self) -> dict:
-        return dict(self._data)
-
-
-class _ILocIndexer:
-    __slots__ = ("_df",)
-
-    def __init__(self, df: "SimpleDataFrame") -> None:
-        self._df = df
-
-    def __getitem__(self, index: int | slice):
-        if isinstance(index, slice):
-            rows = self._df._rows[index]
-            return SimpleDataFrame(rows, columns=self._df._columns)
-        return _Row(self._df._rows[index])
-
-
-class _LocIndexer:
-    __slots__ = ("_df",)
-
-    def __init__(self, df: "SimpleDataFrame") -> None:
-        self._df = df
-
-    def __getitem__(self, key: tuple) -> Series:
-        mask, column = key
-        indices = self._df._mask_to_indices(mask)
-        values = [self._df._rows[i].get(column) for i in indices]
-        return Series(self._df, column, values, indices)
-
-    def __setitem__(self, key: tuple, value) -> None:
-        mask, column = key
-        indices = self._df._mask_to_indices(mask)
-        for idx in indices:
-            self._df._rows[idx][column] = value
-
-
-class SimpleDataFrame:
-    __slots__ = ("_rows", "_columns")
-
-    def __init__(self, rows: Sequence[dict], *, columns: Sequence[str] | None = None) -> None:
-        self._rows = [dict(row) for row in rows]
-        if columns is None:
-            if rows:
-                columns = list(rows[0].keys())
-            else:
-                columns = list(DEFAULT_COLUMNS)
-        self._columns = list(columns)
-
-    @property
-    def empty(self) -> bool:
-        return not self._rows
-
-    def to_dict(self, orient: str = "records") -> list:
-        if orient != "records":  # pragma: no cover - defensive fallback
-            raise ValueError("Only records orient is supported")
-        return [dict(row) for row in self._rows]
-
-    def head(self, count: int) -> "SimpleDataFrame":
-        return SimpleDataFrame(self._rows[:count], columns=self._columns)
-
-    def __getitem__(self, key):
-        if isinstance(key, str):
-            values = [row.get(key) for row in self._rows]
-            return Series(self, key, values, range(len(self._rows)))
-        mask_values = self._mask_to_bools(key)
-        rows = [self._rows[i] for i, keep in enumerate(mask_values) if keep]
-        return SimpleDataFrame(rows, columns=self._columns)
-
-    def _mask_to_bools(self, mask) -> List[bool]:
-        if isinstance(mask, Mask):
-            bools = mask.values
-        elif isinstance(mask, Series):
-            bools = [bool(value) for value in mask]
-        elif isinstance(mask, Sequence):
-            bools = [bool(value) for value in mask]
-        else:  # pragma: no cover - defensive fallback
-            raise TypeError("Unsupported mask type")
-        if len(bools) != len(self._rows):
-            raise ValueError("Mask length mismatch")
-        return bools
-
-    def _mask_to_indices(self, mask) -> List[int]:
-        return [idx for idx, keep in enumerate(self._mask_to_bools(mask)) if keep]
-
-    @property
-    def iloc(self) -> _ILocIndexer:
-        return _ILocIndexer(self)
-
-    @property
-    def loc(self) -> _LocIndexer:
-        return _LocIndexer(self)
-
-    def to_csv(self, path: Path | str, index: bool = False) -> None:  # noqa: ARG002
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", newline="", encoding="utf-8") as handle:
-            writer = csv.DictWriter(handle, fieldnames=self._columns)
-            writer.writeheader()
-            for row in self._rows:
-                writer.writerow({column: row.get(column, "") for column in self._columns})
-
-    @classmethod
-    def from_csv(cls, path: Path | str) -> "SimpleDataFrame":
-        path = Path(path)
-        if not path.exists():
-            return cls([], columns=DEFAULT_COLUMNS)
-        with path.open(newline="", encoding="utf-8") as handle:
-            reader = csv.DictReader(handle)
-            rows = [dict(row) for row in reader]
-            columns = reader.fieldnames or list(DEFAULT_COLUMNS)
-        return cls(rows, columns=columns)
-
-
-def _ensure_dataframe(obj):
-    if pd is not None and isinstance(obj, pd.DataFrame):
-        return obj
-    if isinstance(obj, SimpleDataFrame):
-        return obj
-    raise TypeError("Unsupported dataframe type")
-
-
-def load_schedule():
+def load_schedule() -> pd.DataFrame:
     if not SCHEDULE_FILE.exists():
-        if pd is not None:
-            return pd.DataFrame(columns=list(DEFAULT_COLUMNS))
-        return SimpleDataFrame([], columns=DEFAULT_COLUMNS)
-    if pd is not None:
-        return pd.read_csv(SCHEDULE_FILE)
-    return SimpleDataFrame.from_csv(SCHEDULE_FILE)
+        return pd.DataFrame()
+    df = pd.read_csv(SCHEDULE_FILE, dtype=str)
+    expected = [
+        "date",
+        "weekday",
+        "start_time",
+        "end_time",
+        "status",
+        "patient_name",
+        "appointment_type",
+        "notes",
+    ]
+    for col in expected:
+        if col not in df.columns:
+            df[col] = ""
+    return df[expected]
 
 
-def save_schedule(df):
-    if pd is not None and isinstance(df, pd.DataFrame):
-        df.to_csv(SCHEDULE_FILE, index=False)
-    elif isinstance(df, SimpleDataFrame):
-        df.to_csv(SCHEDULE_FILE, index=False)
-    else:  # pragma: no cover - defensive fallback
-        raise TypeError("Unsupported dataframe type for saving")
+def save_schedule(df: pd.DataFrame) -> None:
+    df.to_csv(SCHEDULE_FILE, index=False)
 
 
-def list_available(date=None, limit=5):
+def list_available(date: str | None = None, limit: int = 6):
     df = load_schedule()
-    df = _ensure_dataframe(df)
     if df.empty:
         return []
     avail = df[df["status"] == "Available"]
     if date:
         avail = avail[avail["date"] == date]
-    if avail.empty:
-        return []
     return avail.head(limit).to_dict(orient="records")
 
 
-def find_next_available(after_date):  # noqa: ARG001 - kept for API parity
+def find_next_available() -> dict | None:
     df = load_schedule()
-    df = _ensure_dataframe(df)
     if df.empty:
         return None
     avail = df[df["status"] == "Available"]
@@ -261,19 +56,22 @@ def find_next_available(after_date):  # noqa: ARG001 - kept for API parity
     return avail.iloc[0].to_dict()
 
 
-def reserve_slot(date, start_time, name, appt_type):
+def reserve_slot(date: str, start_time: str, name: str, appt_type: str) -> bool:
     df = load_schedule()
-    df = _ensure_dataframe(df)
+    if df.empty:
+        return False
     mask = (df["date"] == date) & (df["start_time"] == start_time)
     if not mask.any():
         return False
-    if df.loc[mask, "status"].iloc[0] != "Available":
+    if (df.loc[mask, "status"].iloc[0] or "").strip() != "Available":
         return False
     df.loc[mask, "status"] = "Booked"
     df.loc[mask, "patient_name"] = name
     df.loc[mask, "appointment_type"] = appt_type
     save_schedule(df)
-    BOOKINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if not BOOKINGS_FILE.exists():
+        BOOKINGS_FILE.write_text("timestamp,call_sid,caller_name,requested_time,intent\n", encoding="utf-8")
     with BOOKINGS_FILE.open("a", encoding="utf-8") as handle:
-        handle.write(f"{date},{start_time},{name},{appt_type}\n")
+        handle.write(f"{pd.Timestamp.now().isoformat()},{''},{name},{date} {start_time},book\n")
     return True
+

--- a/main.py
+++ b/main.py
@@ -13,7 +13,8 @@ from fastapi.responses import JSONResponse, Response
 from twilio.twiml.voice_response import VoiceResponse
 
 from app.config import get_settings
-from app.dialogue import AVAILABILITY_OPTIONS, CONFIRMATIONS, DISCLAIMER_LINE, GREETINGS
+from app import nlp, schedule
+from app.dialogue import CONFIRM_TEMPLATES, DISCLAIMER_LINE, GREETINGS
 from app.intent import parse_intent
 from app.logging_config import setup_logging
 from app.persistence import (
@@ -334,68 +335,140 @@ def _respond_with_goodbye(state: Dict[str, Any]) -> Response:
     )
 
 
-def _booking_time_prompt(name: Optional[str]) -> str:
-    if name:
-        return BOOKING_TIME_PROMPT_TEMPLATE.format(name=name)
-    return BOOKING_TIME_PROMPT
+def _booking_type_prompt() -> str:
+    return "Sure, what type of appointment would you like? For example check-up, hygiene, or whitening?"
 
 
-def _booking_name_prompt_text(requested_time: Optional[str]) -> str:
-    if requested_time:
-        return f"Great, I can hold {requested_time}. {BOOKING_NAME_PROMPT}"
-    return BOOKING_NAME_PROMPT
+def _booking_type_reprompt() -> str:
+    return "We can do check-up, hygiene, whitening, filling, or emergency. Which would you like?"
 
 
-def _booking_confirmation_prompt(name: Optional[str], requested_time: Optional[str]) -> str:
-    when = requested_time or "that time"
-    confirmation = random.choice(CONFIRMATIONS).format(slot=when)
-    if name:
-        return f"Thanks {name}. {confirmation}"
-    return f"Thanks. {confirmation}"
+def _booking_date_prompt(appt_type: str) -> str:
+    return f"Great, a {appt_type} — what day works best for you?"
 
 
-def _booking_confirmed_message(name: Optional[str], requested_time: Optional[str]) -> str:
-    when = requested_time or "that time"
-    if name:
-        return f"Brilliant, {name}. I've noted {when} and the team will confirm shortly. {ANYTHING_ELSE_PROMPT}"
-    return f"Brilliant. I've noted {when} and the team will confirm shortly. {ANYTHING_ELSE_PROMPT}"
+def _booking_date_reprompt() -> str:
+    return "Which day works best for you? You can say tomorrow or a weekday like Wednesday."
 
 
-def _format_availability_options(options: Sequence[str]) -> str:
-    cleaned = [option.strip() for option in options if option and option.strip()]
-    if not cleaned:
-        return ""
-    if len(cleaned) == 1:
-        return cleaned[0]
-    if len(cleaned) == 2:
-        return " or ".join(cleaned)
-    return ", ".join(cleaned[:-1]) + f", or {cleaned[-1]}"
-
-
-def _availability_prompt() -> str:
-    slots = _format_availability_options(AVAILABILITY_OPTIONS)
+def _format_times(slots: Sequence[str]) -> str:
     if not slots:
-        return "We can be flexible with appointments. Which time works for you?"
-    return f"We have {slots}. Which of those times works for you?"
+        return ""
+    if len(slots) == 1:
+        return slots[0]
+    if len(slots) == 2:
+        return " or ".join(slots)
+    return ", ".join(slots[:-1]) + f", or {slots[-1]}"
 
 
-def _offer_availability(state: Dict[str, Any], *, clear_name: bool = False) -> Response:
-    if clear_name:
-        state["caller_name"] = None
+def _booking_time_prompt(date: str, slots: Sequence[str]) -> str:
+    joined = _format_times(list(slots))
+    if not joined:
+        return "I couldn't see any free times on that day. Would another day work?"
+    return f"On {date}, we have {joined}. Which time works for you?"
+
+
+def _booking_time_reprompt(slots: Sequence[str]) -> str:
+    cleaned = [slot for slot in slots if slot]
+    if cleaned:
+        preview = ", ".join(cleaned[:3])
+        return f"Times available are {preview}. Which would you like?"
+    return "What time suits you? You can say ten a m, ten thirty, or three p m."
+
+
+def _booking_name_prompt(time: str) -> str:
+    return f"Okay, {time} noted. And your name please?"
+
+
+def _booking_confirm_prompt(state: Dict[str, Any]) -> str:
+    return (
+        f"Great, {state['caller_name']}. Shall I book you in for {state['booking_appt_type']} "
+        f"on {state['booking_date']} at {state['booking_time']}?"
+    )
+
+
+def _booking_confirmed_message(state: Dict[str, Any]) -> str:
+    msg = random.choice(CONFIRM_TEMPLATES).format(
+        date=state["booking_date"],
+        time=state["booking_time"],
+        type=state["booking_appt_type"],
+        name=state["caller_name"] or "",
+    )
+    return f"{msg} Anything else I can help with?"
+
+
+def _reset_booking_context(state: Dict[str, Any]) -> None:
     state["intent"] = "booking"
+    state["booking_appt_type"] = None
+    state["booking_date"] = None
+    state["booking_time"] = None
+    state["booking_available_times"] = []
+    state["requested_time"] = None
+    state["caller_name"] = None
+    state["booking_logged"] = False
+    state["booking_suggested_slot"] = None
+
+
+def _available_slots_for_date(date: str, limit: int = 6) -> list[str]:
+    slots = schedule.list_available(date=date, limit=limit)
+    return [slot["start_time"] for slot in slots]
+
+
+def _next_available_slot() -> Optional[dict]:
+    return schedule.find_next_available()
+
+
+def _match_appointment_type(text: str) -> Optional[str]:
+    cleaned = (text or "").strip().lower()
+    if not cleaned:
+        return None
+    for appt in schedule.APPT_TYPES:
+        if cleaned == appt.lower():
+            return appt
+    for appt in schedule.APPT_TYPES:
+        if cleaned in appt.lower():
+            return appt
+    return None
+
+
+def _handle_availability_request(state: Dict[str, Any], user_input: str) -> Response:
+    date = nlp.parse_date_phrase(user_input)
+    if not date:
+        state["stage"] = "booking_date"
+        state["silence_count"] = 0
+        state["retries"] = 0
+        state["booking_date"] = None
+        state["booking_available_times"] = []
+        return _respond_with_gather(
+            state,
+            "Sure — which day are you thinking of? You can say tomorrow or a weekday like Wednesday.",
+            action="/gather-booking",
+        )
+
+    slots = _available_slots_for_date(date)
+    if not slots:
+        nxt = _next_available_slot()
+        if nxt:
+            message = (
+                f"That day looks full. The next available is {nxt['date']} at {nxt['start_time']}. Would you like that?"
+            )
+        else:
+            message = "Sorry, I can’t see any free times right now."
+        state["booking_date"] = date
+        state["booking_available_times"] = []
+        state["stage"] = "booking_date"
+        state["silence_count"] = 0
+        state["retries"] = 0
+        return _respond_with_gather(state, message, action="/gather-booking")
+
+    state.setdefault("intent", "booking")
+    state["booking_date"] = date
+    state["booking_available_times"] = slots
     state["stage"] = "booking_time"
     state["silence_count"] = 0
     state["retries"] = 0
-    state["requested_time"] = None
-    logger.info(
-        "Offering availability options",
-        extra={"call_sid": state.get("call_sid")},
-    )
-    return _respond_with_gather(
-        state,
-        _availability_prompt(),
-        action="/gather-booking",
-    )
+    prompt = _booking_time_prompt(date, slots)
+    return _respond_with_gather(state, prompt, action="/gather-booking")
 
 
 def _extract_first_name(text: str) -> Optional[str]:
@@ -441,14 +514,12 @@ def _handle_silence(
 
 
 def _start_booking(state: Dict[str, Any]) -> Response:
-    state["intent"] = "booking"
-    state["caller_name"] = None
-    state["requested_time"] = None
-    state["stage"] = "booking_time"
+    _reset_booking_context(state)
+    state["stage"] = "booking_type"
     state["silence_count"] = 0
     state["retries"] = 0
     logger.info("Booking flow started", extra={"call_sid": state.get("call_sid")})
-    return _respond_with_gather(state, _booking_time_prompt(None), action="/gather-booking")
+    return _respond_with_gather(state, _booking_type_prompt(), action="/gather-booking")
 
 
 def _handle_primary_intent(state: Dict[str, Any], intent: Optional[str], user_input: str) -> Response:
@@ -463,7 +534,9 @@ def _handle_primary_intent(state: Dict[str, Any], intent: Optional[str], user_in
         logger.info("Providing information", extra={"call_sid": state.get("call_sid"), "intent": intent})
         return _respond_with_gather(state, message)
     if intent == "availability":
-        return _offer_availability(state, clear_name=True)
+        if state.get("intent") != "booking":
+            _reset_booking_context(state)
+        return _handle_availability_request(state, user_input)
     if intent == "booking":
         return _start_booking(state)
     if intent == "affirm" or lowered in POSITIVE_RESPONSES:
@@ -478,7 +551,9 @@ def _handle_follow_up(state: Dict[str, Any], intent: Optional[str], user_input: 
     if intent == "goodbye" or lowered in NEGATIVE_RESPONSES:
         return _respond_with_goodbye(state)
     if intent == "availability":
-        return _offer_availability(state, clear_name=True)
+        if state.get("intent") != "booking":
+            _reset_booking_context(state)
+        return _handle_availability_request(state, user_input)
     if intent in INFO_LINES or intent == "booking":
         state["stage"] = "intent"
         return _handle_primary_intent(state, intent, user_input)
@@ -489,30 +564,80 @@ def _handle_follow_up(state: Dict[str, Any], intent: Optional[str], user_input: 
     return _respond_with_gather(state, CLARIFY_PROMPT)
 
 
-def _handle_booking_name(state: Dict[str, Any], user_input: str, intent: Optional[str]) -> Response:
+def _handle_booking_type(state: Dict[str, Any], user_input: str, intent: Optional[str]) -> Response:
     if intent == "goodbye":
         return _respond_with_goodbye(state)
     if intent in INFO_LINES:
         state["stage"] = "intent"
         return _handle_primary_intent(state, intent, user_input)
     if intent == "availability":
-        return _offer_availability(state)
-    name = _extract_first_name(user_input)
-    if not name:
+        return _handle_availability_request(state, user_input)
+
+    match = _match_appointment_type(user_input)
+    if not match:
         state["retries"] += 1
-        return _respond_with_gather(state, BOOKING_NAME_REPROMPT, action="/gather-booking")
-    state["caller_name"] = name
-    state["stage"] = "booking_confirm"
+        return _respond_with_gather(state, _booking_type_reprompt(), action="/gather-booking")
+
+    state["booking_appt_type"] = match
     state["silence_count"] = 0
+    state["retries"] = 0
     logger.info(
-        "Captured caller name",
-        extra={"call_sid": state.get("call_sid"), "caller_name": name},
+        "Captured appointment type",
+        extra={"call_sid": state.get("call_sid"), "appointment_type": match},
     )
-    return _respond_with_gather(
-        state,
-        _booking_confirmation_prompt(state.get("caller_name"), state.get("requested_time")),
-        action="/gather-booking",
-    )
+    if state.get("booking_date") and state.get("booking_time"):
+        state["stage"] = "booking_name"
+        return _respond_with_gather(state, _booking_name_prompt(state["booking_time"]), action="/gather-booking")
+    state["stage"] = "booking_date"
+    return _respond_with_gather(state, _booking_date_prompt(match), action="/gather-booking")
+
+
+def _handle_booking_date(state: Dict[str, Any], user_input: str, intent: Optional[str]) -> Response:
+    lowered = user_input.lower().strip()
+    if intent == "goodbye" or lowered in NEGATIVE_RESPONSES:
+        return _respond_with_goodbye(state)
+    if intent in INFO_LINES:
+        state["stage"] = "intent"
+        return _handle_primary_intent(state, intent, user_input)
+    if intent == "availability":
+        return _handle_availability_request(state, user_input)
+
+    suggested = state.get("booking_suggested_slot")
+    if suggested and (intent == "affirm" or lowered in POSITIVE_RESPONSES):
+        state["booking_date"] = suggested["date"]
+        state["booking_time"] = suggested["start_time"]
+        state["booking_available_times"] = [suggested["start_time"]]
+        state["requested_time"] = f"{suggested['date']} {suggested['start_time']}"
+        state["booking_suggested_slot"] = None
+        state["stage"] = "booking_name"
+        state["silence_count"] = 0
+        return _respond_with_gather(state, _booking_name_prompt(suggested["start_time"]), action="/gather-booking")
+
+    parsed = nlp.parse_date_phrase(user_input)
+    if not parsed:
+        state["retries"] += 1
+        return _respond_with_gather(state, _booking_date_reprompt(), action="/gather-booking")
+
+    state["booking_date"] = parsed
+    slots = _available_slots_for_date(parsed)
+    state["booking_available_times"] = slots
+    state["booking_suggested_slot"] = None
+    state["silence_count"] = 0
+    state["retries"] = 0
+    if not slots:
+        nxt = _next_available_slot()
+        if nxt:
+            state["booking_suggested_slot"] = nxt
+            message = (
+                f"Sorry, no free times on that day. The next available is {nxt['date']} at {nxt['start_time']}. Would you like that?"
+            )
+        else:
+            message = "Sorry, I can’t see any available times in the schedule right now."
+        return _respond_with_gather(state, message, action="/gather-booking")
+
+    state["stage"] = "booking_time"
+    prompt = _booking_time_prompt(parsed, slots)
+    return _respond_with_gather(state, prompt, action="/gather-booking")
 
 
 def _handle_booking_time(state: Dict[str, Any], user_input: str, intent: Optional[str]) -> Response:
@@ -522,26 +647,72 @@ def _handle_booking_time(state: Dict[str, Any], user_input: str, intent: Optiona
         state["stage"] = "intent"
         return _handle_primary_intent(state, intent, user_input)
     if intent == "availability":
-        return _offer_availability(state)
-    state["requested_time"] = user_input
-    state["silence_count"] = 0
-    logger.info(
-        "Captured requested time",
-        extra={"call_sid": state.get("call_sid"), "requested_time": user_input},
-    )
-    if state.get("caller_name"):
-        state["stage"] = "booking_confirm"
+        return _handle_availability_request(state, user_input)
+
+    hhmm = nlp.normalize_time(user_input)
+    if not hhmm:
+        state["retries"] += 1
         return _respond_with_gather(
             state,
-            _booking_confirmation_prompt(state.get("caller_name"), state.get("requested_time")),
+            _booking_time_reprompt(state.get("booking_available_times", [])),
             action="/gather-booking",
         )
-    state["stage"] = "booking_name"
-    return _respond_with_gather(
-        state,
-        _booking_name_prompt_text(state.get("requested_time")),
-        action="/gather-booking",
+
+    avail = set(state.get("booking_available_times") or [])
+    if state.get("booking_date") and not avail:
+        avail = set(_available_slots_for_date(state["booking_date"]))
+        state["booking_available_times"] = list(avail)
+    if avail and hhmm not in avail:
+        state["retries"] += 1
+        return _respond_with_gather(
+            state,
+            _booking_time_reprompt(list(avail)),
+            action="/gather-booking",
+        )
+
+    state["booking_time"] = hhmm
+    if state.get("booking_date"):
+        state["requested_time"] = f"{state['booking_date']} {hhmm}"
+    else:
+        state["requested_time"] = hhmm
+    state["silence_count"] = 0
+    state["retries"] = 0
+    logger.info(
+        "Captured booking time",
+        extra={"call_sid": state.get("call_sid"), "time": hhmm, "date": state.get("booking_date")},
     )
+
+    if state.get("booking_appt_type"):
+        state["stage"] = "booking_name"
+        return _respond_with_gather(state, _booking_name_prompt(hhmm), action="/gather-booking")
+
+    state["stage"] = "booking_type"
+    return _respond_with_gather(state, _booking_type_prompt(), action="/gather-booking")
+
+
+def _handle_booking_name(state: Dict[str, Any], user_input: str, intent: Optional[str]) -> Response:
+    if intent == "goodbye":
+        return _respond_with_goodbye(state)
+    if intent in INFO_LINES:
+        state["stage"] = "intent"
+        return _handle_primary_intent(state, intent, user_input)
+    if intent == "availability":
+        return _handle_availability_request(state, user_input)
+
+    name = _extract_first_name(user_input)
+    if not name:
+        state["retries"] += 1
+        return _respond_with_gather(state, BOOKING_NAME_REPROMPT, action="/gather-booking")
+
+    state["caller_name"] = name
+    state["stage"] = "booking_confirm"
+    state["silence_count"] = 0
+    state["retries"] = 0
+    logger.info(
+        "Captured caller name",
+        extra={"call_sid": state.get("call_sid"), "caller_name": name},
+    )
+    return _respond_with_gather(state, _booking_confirm_prompt(state), action="/gather-booking")
 
 
 def _handle_booking_confirmation(state: Dict[str, Any], user_input: str, intent: Optional[str]) -> Response:
@@ -553,40 +724,34 @@ def _handle_booking_confirmation(state: Dict[str, Any], user_input: str, intent:
         state["stage"] = "intent"
         return _handle_primary_intent(state, intent, user_input)
     if intent == "availability":
-        return _offer_availability(state)
+        return _handle_availability_request(state, user_input)
+
     if intent == "affirm" or lowered in POSITIVE_RESPONSES:
-        if not state.get("booking_logged") and state.get("requested_time"):
-            append_booking(
-                state.get("call_sid", ""),
-                state.get("caller_name"),
-                state.get("requested_time"),
-            )
+        date = state.get("booking_date")
+        time = state.get("booking_time")
+        name = state.get("caller_name") or ""
+        appt_type = state.get("booking_appt_type") or ""
+        if not (date and time and name and appt_type):
+            state["stage"] = "booking_type"
+            return _respond_with_gather(state, _booking_type_prompt(), action="/gather-booking")
+        ok = schedule.reserve_slot(date, time, name, appt_type)
+        if ok:
+            state["requested_time"] = f"{date} {time}"
             state["booking_logged"] = True
-            logger.info(
-                "Logged booking request",
-                extra={
-                    "call_sid": state.get("call_sid"),
-                    "caller_name": state.get("caller_name"),
-                    "requested_time": state.get("requested_time"),
-                },
-            )
-        state["stage"] = "follow_up"
-        state["intent"] = "booking"
+            state["stage"] = "follow_up"
+            state["intent"] = "booking"
+            return _respond_with_gather(state, _booking_confirmed_message(state))
+        state["stage"] = "booking_date"
+        state["booking_time"] = None
+        state["booking_available_times"] = _available_slots_for_date(date) if date else []
         return _respond_with_gather(
             state,
-            _booking_confirmed_message(state.get("caller_name"), state.get("requested_time")),
+            "Sorry, that slot was just taken. Would you like to pick another time?",
+            action="/gather-booking",
         )
-    # Treat other responses as a revised time request
-    state["requested_time"] = user_input
-    logger.info(
-        "Clarifying booking time",
-        extra={"call_sid": state.get("call_sid"), "requested_time": user_input},
-    )
-    return _respond_with_gather(
-        state,
-        _booking_confirmation_prompt(state.get("caller_name"), state.get("requested_time")),
-        action="/gather-booking",
-    )
+
+    state["retries"] += 1
+    return _respond_with_gather(state, _booking_confirm_prompt(state), action="/gather-booking")
 
 
 @app.get("/health")
@@ -676,10 +841,26 @@ async def gather_booking_route(request: Request) -> Response:
     speech_result = (form.get("SpeechResult") or "").strip()
     stage = state.get("stage")
     if not speech_result:
+        if stage == "booking_type":
+            return _handle_silence(
+                state,
+                reprompt=_booking_type_reprompt(),
+                action="/gather-booking",
+            )
+        if stage == "booking_date":
+            return _handle_silence(
+                state,
+                reprompt=_booking_date_reprompt(),
+                action="/gather-booking",
+            )
         if stage == "booking_name":
             return _handle_silence(state, reprompt=BOOKING_NAME_REPROMPT, action="/gather-booking")
         if stage == "booking_time":
-            return _handle_silence(state, reprompt=BOOKING_TIME_REPROMPT, action="/gather-booking")
+            return _handle_silence(
+                state,
+                reprompt=_booking_time_reprompt(state.get("booking_available_times", [])),
+                action="/gather-booking",
+            )
         if stage == "booking_confirm":
             return _handle_silence(state, reprompt=BOOKING_CONFIRM_REPROMPT, action="/gather-booking")
         return _handle_silence(state, reprompt=CLARIFY_PROMPT)
@@ -689,10 +870,14 @@ async def gather_booking_route(request: Request) -> Response:
 
     intent = parse_intent(speech_result)
 
-    if stage == "booking_name":
-        return _handle_booking_name(state, speech_result, intent)
+    if stage == "booking_type":
+        return _handle_booking_type(state, speech_result, intent)
+    if stage == "booking_date":
+        return _handle_booking_date(state, speech_result, intent)
     if stage == "booking_time":
         return _handle_booking_time(state, speech_result, intent)
+    if stage == "booking_name":
+        return _handle_booking_name(state, speech_result, intent)
     if stage == "booking_confirm":
         return _handle_booking_confirmation(state, speech_result, intent)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.0.1
 twilio==9.3.6
 PyYAML==6.0.2
 httpx==0.27.2
+pandas==2.2.3

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,27 @@
+from datetime import date
+
+from app import nlp, schedule
+
+
+def test_parse_date_phrase_weekday(monkeypatch):
+    monkeypatch.setattr(nlp, "today_date", lambda: date(2025, 9, 22))  # Monday
+    assert nlp.parse_date_phrase("tomorrow") == "2025-09-23"
+    assert nlp.parse_date_phrase("Wednesday") == "2025-09-24"
+
+
+def test_schedule_list_and_reserve(tmp_path, monkeypatch):
+    import shutil
+
+    src = schedule.SCHEDULE_FILE
+    dst = tmp_path / "schedule.csv"
+    shutil.copy(src, dst)
+    monkeypatch.setattr(schedule, "SCHEDULE_FILE", dst)
+    monkeypatch.setattr(schedule, "BOOKINGS_FILE", tmp_path / "bookings.csv")
+
+    avail = schedule.list_available(limit=2)
+    assert isinstance(avail, list)
+
+    if avail:
+        s0 = avail[0]
+        ok = schedule.reserve_slot(s0["date"], s0["start_time"], "TestUser", "Check-up")
+        assert ok

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -7,6 +7,7 @@ def test_schedule_cycle(tmp_path, monkeypatch):
     data_file = tmp_path / "schedule.csv"
     shutil.copy("data/schedule.csv", data_file)
     monkeypatch.setattr(schedule, "SCHEDULE_FILE", data_file)
+    monkeypatch.setattr(schedule, "BOOKINGS_FILE", tmp_path / "bookings.csv")
 
     df = schedule.load_schedule()
     assert not df.empty


### PR DESCRIPTION
## Summary
- add a pandas-backed schedule module plus natural language date/time parsing
- rework booking and availability flows to follow type → date → time → name → confirm and reserve slots
- update tests and docs for schedule-backed availability including new availability test coverage

## Testing
- `pip install -r requirements-dev.txt` *(fails: index access blocked in sandbox)*
- `pytest` *(fails: ModuleNotFoundError for pandas because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d18d8181808330b9995eee89c3f98f