### PR TITLE
Improve availability recognition and booking prompts

### DIFF
--- a/app/dialogue.py
+++ b/app/dialogue.py
@@ -84,9 +84,9 @@ GOODBYES = [
 ]
 
 CLOSINGS = [
-    "Okay, thanks for calling Oak Dental. Goodbye.",
-    "Alright, appreciate the call. Goodbye.",
-    "Thanks for calling. Take care, goodbye.",
+    "Okay, thanks for calling — have a lovely day. Goodbye.",
+    "Alright, I appreciate the call. Take care, goodbye.",
+    "Thanks for calling. Have a great day. Goodbye.",
 ]
 
 CONFIRM_TEMPLATES = [
@@ -218,7 +218,7 @@ def booking_flow(state, transcript: str):
             if not next_avail:
                 return "Sorry, I can’t see any available times in the schedule right now."
             return (
-                "Sorry, no free times on that day. "
+                "Sorry, no free times that day. "
                 f"The next available is {next_avail['date']} at {next_avail['start_time']}. Would you like that?"
             )
         options = ", ".join(slot["start_time"] for slot in avail)
@@ -236,15 +236,12 @@ def booking_flow(state, transcript: str):
             return f"Sorry, {hhmm} isn’t free. Times available are {hint}. Which would you like?"
         state["time"] = hhmm
         state["stage"] = "ask_name"
-        return "Okay, {time} noted. And your name please?".format(time=hhmm)
+        return f"Okay, {state['time']} noted. And your name please?"
 
     if state["stage"] == "ask_name":
         state["name"] = (transcript or "").strip()
         state["stage"] = "confirm"
-        return (
-            f"Great, {state['name']}. Shall I book you in for {state['appt_type']} "
-            f"on {state['date']} at {state['time']}?"
-        )
+        return f"Great, {state['name']}. Shall I book you for {state['appt_type']} on {state['date']} at {state['time']}?"
 
     if state["stage"] == "confirm":
         if (transcript or "").lower().strip() in {"yes", "yeah", "yep", "ok", "okay", "please", "sure"}:
@@ -254,11 +251,11 @@ def booking_flow(state, transcript: str):
                     date=state["date"], time=state["time"], type=state["appt_type"], name=state["name"]
                 )
                 state.clear()
-                return msg + " Anything else I can help with?"
+                return msg + " Is there anything else I can help you with?"
             state.clear()
             return "Sorry, that slot was just taken. Would you like to pick another?"
         state.clear()
-        return "No problem, I won’t reserve it. Anything else I can help with?"
+        return "No problem, I won’t reserve it. Is there anything else I can help you with?"
 
     return "I didn’t quite catch that."
 
@@ -273,8 +270,9 @@ def handle_availability(transcript: str, state) -> str:
         if nxt:
             return f"That day looks full. The next available is {nxt['date']} at {nxt['start_time']}. Would you like that?"
         return "Sorry, I can’t see any free times right now."
-    first = ", ".join(slot["start_time"] for slot in avail[:5])
+    options = ", ".join(slot["start_time"] for slot in avail[:6])
+    state.clear()
     state["stage"] = "ask_time"
     state["date"] = date
-    return f"On {date}, we’ve got {first}. Which time works for you?"
+    return f"On {date}, we have {options}. Which time works for you?"
 

--- a/app/intent.py
+++ b/app/intent.py
@@ -4,7 +4,7 @@ import re
 from typing import Optional
 
 _INTENT_KEYWORDS = {
-    "hours": {"hours", "open", "opening", "times", "time"},
+    "hours": {"hours", "open", "opening", "closing"},
     "address": {"address", "where", "located", "location", "find", "directions"},
     "prices": {"price", "prices", "cost", "fee", "fees", "charges", "how much"},
     "booking": {
@@ -23,15 +23,25 @@ _AVAILABILITY_PATTERNS = {
     "availability",
     "available",
     "what do you have",
+    "what have you got",
     "what times",
-    "what time slots",
+    "times are available",
     "free slots",
     "free time",
     "free appointment",
+    "open slots",
     "what can you do tomorrow",
     "what can you do on",
     "any slots",
     "any availability",
+    "today",
+    "tomorrow",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
 }
 
 _GOODBYE_KEYWORDS = {
@@ -81,6 +91,10 @@ def parse_intent(speech: Optional[str]) -> Optional[str]:
     if any(_contains(keyword) for keyword in booking_keywords):
         return "booking"
 
+    hours_keywords = _INTENT_KEYWORDS.get("hours", set())
+    if any(_contains(keyword) for keyword in hours_keywords):
+        return "hours"
+
     for keyword in _GOODBYE_KEYWORDS:
         if _contains(keyword):
             return "goodbye"
@@ -93,7 +107,7 @@ def parse_intent(speech: Optional[str]) -> Optional[str]:
         return "availability"
 
     for intent, keywords in _INTENT_KEYWORDS.items():
-        if intent == "booking":
+        if intent in {"booking", "hours"}:
             continue
         if any(_contains(keyword) for keyword in keywords):
             return intent

--- a/app/nlp.py
+++ b/app/nlp.py
@@ -36,6 +36,29 @@ def normalize_time(text: str) -> str | None:
     if not text:
         return None
     lowered = text.lower().strip()
+
+    if "half past" in lowered:
+        m2 = re.search(r"half past (\d{1,2})", lowered)
+        if m2:
+            hour = int(m2.group(1))
+            if 0 <= hour < 24:
+                return f"{hour:02d}:30"
+
+    if "quarter past" in lowered:
+        m2 = re.search(r"quarter past (\d{1,2})", lowered)
+        if m2:
+            hour = int(m2.group(1))
+            if 0 <= hour < 24:
+                return f"{hour:02d}:15"
+
+    if "quarter to" in lowered:
+        m2 = re.search(r"quarter to (\d{1,2})", lowered)
+        if m2:
+            hour = int(m2.group(1)) - 1
+            if hour < 0:
+                hour = 23
+            return f"{hour:02d}:45"
+
     match = re.search(r"\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b", lowered)
     if not match:
         return None

--- a/main.py
+++ b/main.py
@@ -507,9 +507,6 @@ def _handle_silence(
     )
     if state["silence_count"] == 1:
         return _respond_with_gather(state, reprompt, action=action)
-    if state["silence_count"] == 2:
-        state["stage"] = "follow_up"
-        return _respond_with_gather(state, ANYTHING_ELSE_PROMPT)
     return _respond_with_goodbye(state)
 
 

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -23,3 +23,5 @@ def test_unknown_returns_none():
 def test_availability_detection():
     assert parse_intent("What do you have?") == "availability"
     assert parse_intent("Any slots available tomorrow?") == "availability"
+    assert parse_intent("What times are available tomorrow?") == "availability"
+    assert parse_intent("Have you got anything on Wednesday?") == "availability"


### PR DESCRIPTION
## Summary
- expand intent parsing so day and availability phrasing are routed to the slot-listing flow while hours keywords still resolve correctly
- accept natural phrasing such as "half past" or "quarter to" when normalising requested appointment times and tighten booking/availability prompts
- ensure the system says a goodbye before hanging up after repeated silence and cover the new language with intent tests

## Testing
- pytest *(fails: pandas dependency unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19c31d8b48330aa977a31961662c7