### PR TITLE
Improve booking flow UX and availability handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A FastAPI + Twilio voice assistant that behaves like a natural, speech-first den
   - The assistant reads `data/schedule.csv` for free times.
   - Phrases like “what do you have tomorrow / on Wednesday” will list real times for that day.
   - Booking order: type → day → time → name → confirm. On confirm, the slot is marked **Booked** in `data/schedule.csv` and a line is appended to `data/bookings.csv`.
+  - After booking the bot asks “Is there anything else I can help you with?” and only then ends with a spoken goodbye. If the caller says “no” or is silent twice, it plays a polite closing and hangs up.
   - If a day is full, it suggests the next available slot.
 - Optional webhook signature validation and JSON-formatted logging controlled via environment variables.
 - Daily self-learning workflow that inspects transcripts, writes suggestions, and opens/updates a GitHub issue for review.
@@ -85,10 +86,10 @@ Copy the HTTPS forwarding URL (for example `https://random.ngrok.app`) for the T
 
 - Greeting (played once): “Hi, thanks for calling our dental practice. I’m your AI receptionist, here to help with general information and booking appointments. Please note, I’m not a medical professional. How can I help you today? You can ask about our opening hours, our address, our prices, or say you’d like to book an appointment.”
 - Intent handling:
-  - “Hours”, “address”, and “prices” replies come directly from `config/practice.yml`, followed by “Is there anything else I can help with?”
+- “Hours”, “address”, and “prices” replies come directly from `config/practice.yml`, followed by “Is there anything else I can help you with?”
   - “Book” triggers a short conversation: first name → preferred day/time → natural confirmation.
   - Unknown speech triggers the clarifier “Do you need our opening hours, address, prices, or would you like to book?”
-- Silences: the first silence repeats the clarifier, the second asks “Is there anything else I can help with?”, and a third silence or “no” ends with a rotating polite goodbye (five variants).
+- Silences: the first silence repeats the clarifier, the second asks “Is there anything else I can help you with?”, and a third silence or “no” ends with a rotating polite goodbye (five variants).
 - Confirmed bookings are logged immediately and acknowledged with “Brilliant… the team will confirm shortly.”
 
 ## Persistence outputs

--- a/app/dialogue.py
+++ b/app/dialogue.py
@@ -5,6 +5,7 @@ import random
 from typing import Optional
 
 from app import nlp, schedule
+from app.intent import extract_appt_type
 
 
 log = logging.getLogger("app.dialogue")
@@ -193,6 +194,11 @@ def booking_flow(state, transcript: str):
 
     if state.get("stage") is None:
         state.clear()
+        inline_type = extract_appt_type(transcript)
+        if inline_type:
+            state["appt_type"] = inline_type
+            state["stage"] = "ask_date"
+            return f"Great, a {inline_type} — what day works best for you?"
         state["stage"] = "ask_type"
         return "Sure, what type of appointment would you like? For example check-up, hygiene, or whitening?"
 

--- a/app/intent.py
+++ b/app/intent.py
@@ -114,4 +114,21 @@ def parse_intent(speech: Optional[str]) -> Optional[str]:
     return None
 
 
-__all__ = ["parse_intent"]
+def extract_appt_type(text: str) -> Optional[str]:
+    """Heuristic helper to detect an appointment type mentioned inline."""
+
+    lowered = (text or "").lower()
+    if not lowered:
+        return None
+
+    types = ["check-up", "check up", "hygiene", "whitening", "filling", "emergency"]
+    for raw in types:
+        if raw in lowered:
+            normalized = raw.replace("check up", "check-up").title()
+            if normalized.startswith("Check"):
+                return "Check-up"
+            return normalized
+    return None
+
+
+__all__ = ["parse_intent", "extract_appt_type"]

--- a/app/nlp.py
+++ b/app/nlp.py
@@ -36,6 +36,7 @@ def normalize_time(text: str) -> str | None:
     if not text:
         return None
     lowered = text.lower().strip()
+    lowered = lowered.replace(".", "")
 
     if "half past" in lowered:
         m2 = re.search(r"half past (\d{1,2})", lowered)

--- a/app/schedule.py
+++ b/app/schedule.py
@@ -40,9 +40,14 @@ def list_available(date: str | None = None, limit: int = 6):
     df = load_schedule()
     if df.empty:
         return []
-    avail = df[df["status"] == "Available"]
+    avail = df[df["status"] == "Available"].copy()
     if date:
         avail = avail[avail["date"] == date]
+    try:
+        avail["__t"] = pd.to_datetime(avail["start_time"], format="%H:%M")
+        avail = avail.sort_values("__t").drop(columns=["__t"])
+    except Exception:
+        pass
     return avail.head(limit).to_dict(orient="records")
 
 

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+import pandas as pd
+
 from app import nlp, schedule
 
 
@@ -25,3 +27,66 @@ def test_schedule_list_and_reserve(tmp_path, monkeypatch):
         s0 = avail[0]
         ok = schedule.reserve_slot(s0["date"], s0["start_time"], "TestUser", "Check-up")
         assert ok
+
+
+def test_time_normalisation():
+    from app import nlp
+
+    assert nlp.normalize_time("4:00 p.m.") == "16:00"
+    assert nlp.normalize_time("4 pm") == "16:00"
+    assert nlp.normalize_time("10") == "10:00"
+
+
+def test_list_available_sorted(monkeypatch):
+    from app import schedule
+
+    data = pd.DataFrame(
+        [
+            {
+                "date": "2025-09-24",
+                "weekday": "Wednesday",
+                "start_time": "16:00",
+                "end_time": "16:30",
+                "status": "Available",
+                "patient_name": "",
+                "appointment_type": "",
+                "notes": "",
+            },
+            {
+                "date": "2025-09-24",
+                "weekday": "Wednesday",
+                "start_time": "09:00",
+                "end_time": "09:30",
+                "status": "Available",
+                "patient_name": "",
+                "appointment_type": "",
+                "notes": "",
+            },
+            {
+                "date": "2025-09-24",
+                "weekday": "Wednesday",
+                "start_time": "16:30",
+                "end_time": "17:00",
+                "status": "Available",
+                "patient_name": "",
+                "appointment_type": "",
+                "notes": "",
+            },
+            {
+                "date": "2025-09-24",
+                "weekday": "Wednesday",
+                "start_time": "11:00",
+                "end_time": "11:30",
+                "status": "Booked",
+                "patient_name": "",  # not available
+                "appointment_type": "",
+                "notes": "",
+            },
+        ]
+    )
+
+    monkeypatch.setattr(schedule, "load_schedule", lambda: data.copy())
+
+    avail = schedule.list_available(date="2025-09-24")
+    times = [slot["start_time"] for slot in avail]
+    assert times == ["09:00", "16:00", "16:30"]

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import date
+from itertools import cycle
 from xml.etree import ElementTree as ET
 
 import main
@@ -26,6 +27,13 @@ def _gather_text(xml: str) -> str:
 def _call_route(route, data: dict[str, str]):
     response = asyncio.run(route(DummyRequest(data)))
     return response
+
+
+def _first_say_text(xml: str) -> str:
+    root = ET.fromstring(xml)
+    say = root.find(".//Say")
+    assert say is not None, "Expected Say element"
+    return (say.text or "").strip()
 
 
 def test_booking_flow_follows_type_date_time_name(monkeypatch):
@@ -92,4 +100,116 @@ def test_booking_flow_follows_type_date_time_name(monkeypatch):
     assert response.status_code == 200
     prompt = _gather_text(response.body.decode()).lower()
     assert "shall i book you in" in prompt
+    CALLS.pop(call_sid, None)
+
+
+def test_inline_type_prefill_skips_type_question(monkeypatch):
+    CALLS.clear()
+    call_sid = "TESTINLINE"
+
+    monkeypatch.setattr(main.nlp, "today_date", lambda: date(2025, 9, 22))
+    monkeypatch.setattr(main.schedule, "list_available", lambda date=None, limit=6: [])
+    monkeypatch.setattr(main.schedule, "find_next_available", lambda: None)
+    monkeypatch.setattr(main.schedule, "reserve_slot", lambda d, t, name, appt: True)
+
+    response = _call_route(voice_webhook, {"CallSid": call_sid})
+    assert response.status_code == 200
+
+    phrase = "I want to book a hygiene appointment on Wednesday"
+    response = _call_route(
+        gather_intent_route,
+        {"CallSid": call_sid, "SpeechResult": phrase},
+    )
+    assert response.status_code == 200
+    prompt = _gather_text(response.body.decode())
+    assert "Great, a Hygiene" in prompt
+    assert "what type" not in prompt.lower()
+
+    state = CALLS.get(call_sid)
+    assert state is not None
+    assert state.get("booking_appt_type") == "Hygiene"
+    assert state.get("stage") == "booking_date"
+    CALLS.pop(call_sid, None)
+
+
+def test_booking_confirmation_prompts_anything_else_and_goodbye(monkeypatch):
+    CALLS.clear()
+    call_sid = "TESTCLOSE"
+
+    monkeypatch.setattr(main.nlp, "today_date", lambda: date(2025, 9, 22))
+
+    slots = [
+        {"date": "2025-09-24", "start_time": "16:00", "end_time": "16:30", "status": "Available"},
+        {"date": "2025-09-24", "start_time": "09:00", "end_time": "09:30", "status": "Available"},
+        {"date": "2025-09-24", "start_time": "16:30", "end_time": "17:00", "status": "Available"},
+    ]
+
+    def fake_list_available(*, date: str | None = None, limit: int = 6):
+        pool = [slot for slot in slots if not date or slot["date"] == date]
+        return pool[:limit]
+
+    monkeypatch.setattr(main.schedule, "list_available", lambda date=None, limit=6: fake_list_available(date=date, limit=limit))
+    monkeypatch.setattr(main.schedule, "find_next_available", lambda: slots[0])
+    monkeypatch.setattr(main.schedule, "reserve_slot", lambda d, t, name, appt: True)
+    monkeypatch.setattr(main, "_goodbye_cycle", cycle(["Thanks for calling, goodbye."]))
+
+    response = _call_route(voice_webhook, {"CallSid": call_sid})
+    assert response.status_code == 200
+
+    response = _call_route(
+        gather_intent_route,
+        {"CallSid": call_sid, "SpeechResult": "I'd like to book an appointment"},
+    )
+    assert response.status_code == 200
+
+    response = _call_route(
+        gather_booking_route,
+        {"CallSid": call_sid, "SpeechResult": "Hygiene"},
+    )
+    prompt = _gather_text(response.body.decode())
+    assert "what day" in prompt.lower()
+
+    response = _call_route(
+        gather_booking_route,
+        {"CallSid": call_sid, "SpeechResult": "Wednesday"},
+    )
+    prompt = _gather_text(response.body.decode())
+    assert "2025-09-24" in prompt
+    assert "09:00" in prompt
+    assert "16:30" in prompt
+
+    response = _call_route(
+        gather_booking_route,
+        {"CallSid": call_sid, "SpeechResult": "4:00 p.m."},
+    )
+    prompt = _gather_text(response.body.decode())
+    assert "name" in prompt.lower()
+
+    response = _call_route(
+        gather_booking_route,
+        {"CallSid": call_sid, "SpeechResult": "Alice"},
+    )
+    prompt = _gather_text(response.body.decode())
+    assert "shall i book you in" in prompt.lower()
+
+    response = _call_route(
+        gather_booking_route,
+        {"CallSid": call_sid, "SpeechResult": "yes please"},
+    )
+    prompt = _gather_text(response.body.decode())
+    assert "Is there anything else I can help you with?" in prompt
+
+    response = _call_route(
+        gather_intent_route,
+        {"CallSid": call_sid, "SpeechResult": "No thanks"},
+    )
+    assert response.status_code == 200
+    farewell = _first_say_text(response.body.decode())
+    assert farewell == "Thanks for calling, goodbye."
+
+    state = CALLS.get(call_sid)
+    assert state is not None
+    transcript_lines = state.get("transcript") or []
+    assert any("Is there anything else I can help you with?" in line for line in transcript_lines)
+    assert any("Thanks for calling, goodbye." in line for line in transcript_lines)
     CALLS.pop(call_sid, None)


### PR DESCRIPTION
## Summary
- prefill appointment type when callers mention it and adjust booking follow-up prompts
- normalise time parsing and sort available times before presenting options
- ensure goodbye handling is logged plus add coverage for inline types, closing prompts, and time normalisation

## Testing
- `pytest` *(fails: pandas dependency unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a334b5dc83308f89c1bc5d1c0360