### PR TITLE
Improve speech cadence and consent placement

### DIFF
--- a/app/dialogue.py
+++ b/app/dialogue.py
@@ -19,6 +19,9 @@ GREETINGS = [
     "Hi there, Oak Dental — what do you need today?",
     "Oak Dental here. How can I help you?",
     "Thanks for calling Oak Dental. What can I do for you?",
+    "Hiya, you’ve reached Oak Dental. How can I help?",
+    "Good afternoon, Oak Dental speaking. What can I do for you today?",
+    "Hello there, Oak Dental. Are you calling to book, or for info?",
 ]
 
 DISCLAIMER_LINE = "Just so you know, I’m your AI receptionist, not a medical professional."
@@ -48,6 +51,9 @@ HOLDERS = [
     "Great, thanks.",
     "Lovely, thanks.",
     "No worries.",
+    "Let me check that.",
+    "Bear with me.",
+    "Thanks, just a sec.",
 ]
 
 CLARIFIERS = [
@@ -62,6 +68,12 @@ CLARIFIERS = [
 ]
 
 THINKING_FILLERS = [
+    "Okay.",
+    "Sure.",
+    "Right.",
+    "No problem.",
+    "All good.",
+    "One moment.",
     "Okay, one moment while I check.",
     "Alright, let me have a quick look.",
     "No worries, give me a second.",

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -19,9 +19,13 @@ def _gather_text(xml: str) -> str:
     root = ET.fromstring(xml)
     gather = root.find("Gather")
     assert gather is not None, "Expected Gather element"
-    say = gather.find("Say")
-    assert say is not None, "Expected Say within Gather"
-    return (say.text or "").strip()
+    texts = []
+    for say in gather.findall("Say"):
+        text = (say.text or "").strip()
+        if text:
+            texts.append(text)
+    assert texts, "Expected Say within Gather"
+    return " ".join(texts)
 
 
 def _call_route(route, data: dict[str, str]):
@@ -198,6 +202,7 @@ def test_booking_confirmation_prompts_anything_else_and_goodbye(monkeypatch):
     )
     prompt = _gather_text(response.body.decode())
     assert "Is there anything else I can help you with?" in prompt
+    assert "By providing your number, you agree to receive appointment confirmations and reminders." in prompt
 
     response = _call_route(
         gather_intent_route,


### PR DESCRIPTION
## Summary
- split long prompts into multiple TwiML <Say> elements via a new speech chunking helper for more natural delivery
- expand greeting/backchannel filler options and adjust filler handling to play short processing cues
- present the consent line during booking confirmation as its own message and extend tests to cover the new flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30dfadb58833086db13bc9ee392b4