### PR TITLE
Improve conversational flow, pricing prompts, and service tracking

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,7 +32,9 @@ class PracticeConfig:
     hours: str
     address: str
     prices: str
-    services: dict[str, str]
+    service_prices: dict[str, str]
+    no_speech_timeout: int
+    max_silence_reprompts: int
 
 
 def _load_practice_config() -> PracticeConfig:
@@ -45,12 +47,14 @@ def _load_practice_config() -> PracticeConfig:
         ),
         "address": "We’re at 12 High Street, Oakford, OX1 2AB. Entrance next to the pharmacy.",
         "prices": "A routine check-up is forty five pounds. Hygiene is sixty five. Whitening starts from two hundred and fifty.",
-        "services": {
-            "checkup": "Check-up is £45",
-            "hygiene": "Hygiene is £65",
-            "whitening": "Whitening starts from £250",
-            "extraction": "Tooth extraction is £120",
+        "service_prices": {
+            "check-up": "A routine check-up is forty five pounds.",
+            "hygiene": "Hygiene is sixty five pounds.",
+            "whitening": "Whitening starts from two hundred and fifty pounds.",
+            "extraction": "Tooth extraction is one hundred and twenty pounds.",
         },
+        "no_speech_timeout": 5,
+        "max_silence_reprompts": 2,
     }
 
     if PRACTICE_CONFIG_PATH.exists():
@@ -73,7 +77,9 @@ def _load_practice_config() -> PracticeConfig:
         hours=str(defaults.get("hours", "")),
         address=str(defaults.get("address", "")),
         prices=str(defaults.get("prices", "")),
-        services=dict(defaults.get("services", {}) or {}),
+        service_prices=dict(defaults.get("service_prices", {}) or {}),
+        no_speech_timeout=int(defaults.get("no_speech_timeout", 5) or 5),
+        max_silence_reprompts=int(defaults.get("max_silence_reprompts", 2) or 2),
     )
 
 

--- a/config/practice.yml
+++ b/config/practice.yml
@@ -3,11 +3,11 @@ voice: "Polly.Amy"
 language: "en-GB"
 
 openings:
-  - "Hi, Oak Dental. How can I help today?"
-  - "Hello, Oak Dental speaking — how can I help?"
-  - "Hi there, Oak Dental — what do you need today?"
-  - "Oak Dental here. How can I help you?"
-  - "Thanks for calling Oak Dental. What can I do for you?"
+  - "Hi, thanks for calling Oak Dental — how can I help today?"
+  - "Hello, you’ve reached Oak Dental. What can I do for you?"
+  - "Oak Dental, good to hear from you — how can I help?"
+  - "Hi there, Oak Dental speaking. What do you need today?"
+  - "Thanks for calling Oak Dental. How can I help?"
 
 backchannels:
   - "Okay, that's fine."
@@ -22,12 +22,11 @@ backchannels:
   - "Sure thing."
   - "Okay, noted."
   - "All good."
-  - "Sounds good."
-  - "Okay, let me check."
+  - "Bear with me a sec."
   - "One moment."
-  - "Alright, give me a sec."
-  - "Great, thanks."
-  - "Lovely, thanks."
+  - "Let me just check."
+  - "No worries."
+  - "That’s fine."
 
 thinking_fillers:
   - "Okay, one moment while I check."
@@ -51,9 +50,12 @@ closings:
 hours: "We're open Monday to Friday nine to five, Saturday nine to one. Closed Sundays and bank holidays."
 address: "We're at 12 High Street, Oakford, OX1 2AB. Entrance next to the pharmacy."
 prices: "A routine check-up is forty five pounds. Hygiene is sixty five. Whitening starts from two hundred and fifty."
+service_prices:
+  check-up: "A routine check-up is forty five pounds."
+  hygiene: "Hygiene is sixty five pounds."
+  whitening: "Whitening starts from two hundred and fifty pounds."
+  extraction: "Tooth extraction is one hundred and twenty pounds."
 
-services:
-  checkup: "Check-up is £45"
-  hygiene: "Hygiene is £65"
-  whitening: "Whitening starts from £250"
-  extraction: "Tooth extraction is £120"
+# When there’s silence, how long to wait before we reprompt (seconds)
+no_speech_timeout: 3
+max_silence_reprompts: 2


### PR DESCRIPTION
## Summary
- refresh the practice script with varied openings, updated backchannels, and per-service pricing plus silence timeouts
- extend the config loader, NLU utilities, and intent handling to share normalisation, expose service slots, and reuse inferred services across the call flow
- rework booking prompts, price replies, and silence/name handling to shorten gaps, keep ISO context without brackets, and avoid dumping all prices at once

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6f9cddf748330b8f0dd7b621693d3