### PR TITLE
Add mechanic workshop profile and garage intents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ VERIFY_TWILIO_SIGNATURES=false
 DEBUG_LOG_JSON=false
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
+PRACTICE_PROFILE=dental  # change to 'mechanic' to use config/practice_mechanic.yml

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ prices: "A routine check-up is forty five pounds. Hygiene is sixty five. Whiteni
 
 Update these values to match your practice. `TTS_VOICE`/`TTS_LANG` in the environment always take precedence; if neither config nor environment specify a voice the app falls back to `alice` / `en-GB`.
 
+### Profiles (Dental vs Mechanic)
+
+The dental receptionist is enabled by default. To switch to the mechanic workshop persona:
+
+1. Open `.env` and set:
+
+   ```bash
+   PRACTICE_PROFILE=mechanic
+   ```
+
+2. Restart the server so the new config loads:
+
+   ```bash
+   uvicorn main:app --host 0.0.0.0 --port 5173 --reload
+   ```
+
+3. Update `data/schedule.csv` with garage slots if required.
+
+The bot will now speak as **Swift Auto Care**, offer MOT/service/tyre information, and reuse the same scheduling flow.
+
 ## Running locally
 
 ```bash

--- a/config/practice_mechanic.yml
+++ b/config/practice_mechanic.yml
@@ -1,0 +1,56 @@
+# Practice profile: Mechanic workshop
+practice_name: "Swift Auto Care"
+voice: "Polly.Brian"
+language: "en-GB"
+
+openings:
+  - "Hi, Swift Auto Care. How can I help today?"
+  - "Hello, Swift Auto Care speaking. What do you need done on the car?"
+  - "Thanks for calling Swift Auto Care. Are you after an MOT, a service, or a repair?"
+
+backchannels:
+  - "Okay, sure."
+  - "No problem."
+  - "Right, I follow."
+  - "Yeah, that’s fine."
+  - "Got it."
+  - "All good."
+  - "Let me check that."
+  - "One sec."
+  - "Absolutely."
+  - "Sounds good."
+
+clarifiers:
+  - "Could you say that again, please?"
+  - "Do you mean an MOT, a service, tyres, or something else?"
+  - "Was that for this week or next week?"
+  - "What day works for you?"
+
+closings:
+  - "Okay, thanks for calling Swift Auto Care. Goodbye."
+  - "Alright, appreciate the call. Take care, goodbye."
+  - "Thanks for ringing. Have a good one — goodbye."
+
+hours: "We’re open Monday to Friday eight to six, and Saturday nine to two. Closed Sundays and bank holidays."
+address: "We’re on 24 Station Road, Oakford, OX1 4CD — opposite the petrol station."
+prices:
+  mot: "MOT is fifty-five pounds."
+  interim_service: "An interim service starts at one hundred and forty-nine pounds."
+  full_service: "A full service starts at two hundred and forty-nine pounds."
+  diagnostics: "Diagnostics check is sixty pounds."
+  oil_change: "Oil and filter change from eighty-five pounds."
+  brake_pads: "Front brake pads from one hundred and thirty pounds, parts and labour."
+  tyre: "Tyres fitted from fifty-five pounds each, depending on size."
+  aircon: "Air-con re-gas is sixty-five pounds."
+  battery: "Battery replacement from ninety pounds, depending on model."
+
+consent_lines:
+  short_booking: "By giving your number, you agree we can send booking confirmations and reminders by SMS."
+  when_collecting: "When you share your number, you agree to receive appointment texts for this booking."
+  website_form: "Numbers entered on our website agree to SMS confirmations and reminders."
+
+# phrases the bot may use when confirming consent naturally (it will choose 1)
+consent_snippets:
+  - "I’ll text your confirmation. We use your number for booking updates only."
+  - "We’ll send a reminder by text — that okay?"
+  - "I’ll pop you a quick SMS with the details."


### PR DESCRIPTION
## Summary
- load practice configuration based on a PRACTICE_PROFILE env variable and add a Swift Auto Care profile
- extend intent classification and dialogue helpers with garage-specific phrases and consent snippets
- refresh the main call flow to reuse mechanic prompts, map new intents, and surface consent snippets when confirming bookings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d858e77b7c83309bb5e82820604676